### PR TITLE
Change DNS function signatures in CBMC proofs to match code.

### DIFF
--- a/tools/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSHandlePacket/DNShandlePacket_harness.c
@@ -7,9 +7,11 @@
 #include "FreeRTOS_DNS.h"
 #include "FreeRTOS_IP_Private.h"
 
-/* Function prvParseDNSReply is proven to be correct separately. 
+/* Function prvParseDNSReply is proven to be correct separately.
 The proof can be found here: https://github.com/aws/amazon-freertos/tree/master/tools/cbmc/proofs/ParseDNSReply */
-uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier) { }
+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
+			   size_t xBufferLength,
+			   BaseType_t xExpected ) {}
 
 struct xDNSMessage {
 	uint16_t usIdentifier;

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName/DNSgetHostByName_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName/DNSgetHostByName_harness.c
@@ -8,8 +8,8 @@
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_Sockets.h"
 
-/* This assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by 
-MAX_REQ_SIZE. */ 
+/* This assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by
+MAX_REQ_SIZE. */
 
 void *safeMalloc(size_t xWantedSize) {
 	if(xWantedSize == 0) {
@@ -21,7 +21,7 @@ void *safeMalloc(size_t xWantedSize) {
 
 /* Abstraction of FreeRTOS_GetUDPPayloadBuffer. This should be checked later. For now we are allocating a fixed sized memory of size MAX_REQ_SIZE. */
 void * FreeRTOS_GetUDPPayloadBuffer(size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ) {
-	void *pvReturn = safeMalloc(MAX_REQ_SIZE); 
+	void *pvReturn = safeMalloc(MAX_REQ_SIZE);
 	return pvReturn;
 }
 
@@ -32,7 +32,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProt
 }
 
 /* This function only uses the return value of prvParseDNSReply. Hence it returns an unconstrained uint32 value */
-uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier) { }
+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
+			   size_t xBufferLength,
+			   BaseType_t xExpected ) {}
 
 void harness() {
 	size_t len;

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/DNSgetHostByName_a_harness.c
@@ -46,7 +46,9 @@ Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProt
 }
 
 /* This function FreeRTOS_gethostbyname_a only uses the return value of prvParseDNSReply. Hence it returns an unconstrained uint32 value */
-uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer, size_t xBufferLength, TickType_t xIdentifier) { }
+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
+			   size_t xBufferLength,
+			   BaseType_t xExpected ) {}
 
 /* Abstraction of xTaskResumeAll from task pool. This also abstracts the concurrency. */
 BaseType_t xTaskResumeAll(void) { }


### PR DESCRIPTION
Some DNS proofs are failing because the signatures have changed for
some DNS functions stubbed out in the proof harness.  This patch
repairs the proof harnesses (and appears to have cleaned up up some
minor whitespace issues at the same time).

I have confirmed that the three breaking proofs build and run correctly:
DNSHandlePacket
DNSgetHostByName_a
DNSgetHostByName

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.