### PR TITLE
Fix FreeRTOS prvCheckOptions CBMC memory safety error.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1191,6 +1191,7 @@ uint8_t ucLength;
 			corrupted, we don't like to run into invalid memory and crash. */
 			for( ;; )
 			{
+			        if (uxOptionsLength == 0) break;
 				uxResult = prvSingleStepTCPHeaderOptions( pucPtr, uxOptionsLength, pxSocket, xHasSYNFlag );
 				if( uxResult == 0UL )
 				{


### PR DESCRIPTION
This fixes a memory safety error in prvCheckOptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.