### PR TITLE
Fix FreeRTOS prvParseDNSReply CBMC memory safety error.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1197,6 +1197,10 @@ uint16_t usType = 0;
 
 				/* Is there enough data for an IPv4 A record answer and, if so,
 				is this an A record? */
+				if( uxSourceBytesRemaining < sizeof( uint16_t ) )
+				{
+				        return dnsPARSE_ERROR;
+				}
 				usType = usChar2u16( pucByte );
 
 				if( usType == ( uint16_t ) dnsTYPE_A_HOST )


### PR DESCRIPTION
This fixes a memory safety error in prvParseDNSReply

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.