### PR TITLE
Fix FreeRTOS prvCheckOptions CBMC integer underflow.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
@@ -1171,6 +1171,11 @@ uint8_t ucLength;
 
 	/* A character pointer to iterate through the option data */
 	pucPtr = pxTCPHeader->ucOptdata;
+	if( pxTCPHeader->ucTCPOffset < ( 5U << 4U ) )
+	{
+	        /* avoid integer underflow in computation of ucLength */
+  	        return;
+	}
 	ucLength = ( ( ( pxTCPHeader->ucTCPOffset >> 4U ) - 5U ) << 2U );
 	uxOptionsLength = ( size_t ) ucLength;
 	if( pxNetworkBuffer->xDataLength > uxOptionOffset )


### PR DESCRIPTION
This fixes an integer underflow in a bit shifting computation in prvCheckOptions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.