### PR TITLE
Make uncrustify format flower-box comments correctly.

### DIFF
--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -142,6 +142,7 @@ align_pp_define_gap             = 4        # unsigned number
 align_pp_define_span            = 3        # unsigned number
 cmt_cpp_to_c                    = true     # false/true
 cmt_star_cont                   = true     # false/true
+cmt_sp_before_star_cont         = 1        # unsigned number
 mod_full_brace_do               = add      # ignore/add/remove/force
 mod_full_brace_for              = add      # ignore/add/remove/force
 mod_full_brace_if               = add      # ignore/add/remove/force


### PR DESCRIPTION
Make uncrustify format flower-box comment correctly.  This one-line change to the configuration file makes uncrustify line up the star ('`*`') at the head of a comment line with the star ('`*`') at the head of the preceeding comment line in a multi-line comment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.