### PR TITLE
Make FreeRTOS prvCreateDNSSocket check FreeRTOS_socket return code.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
@@ -1562,6 +1562,10 @@ BaseType_t xReturn;
 	/* This must be the first time this function has been called.  Create
 	the socket. */
 	xSocket = FreeRTOS_socket( FREERTOS_AF_INET, FREERTOS_SOCK_DGRAM, FREERTOS_IPPROTO_UDP );
+	if (xSocket == FREERTOS_INVALID_SOCKET)
+	{
+	    return NULL;
+	}
 
 	/* Auto bind the port. */
 	xAddress.sin_port = 0U;


### PR DESCRIPTION
Make prvCreateDNSSocket check the return code of FreeRTOS_socket.  The FreeRTOS_socket method is allowed to return FREERTOS_INVALID_SOCKET.  The prvCreateDNSSocket calls FreeRTOS_socket and then possibly calls FreeRTOS_bind and FreeRTOS_close without checking that the socket is valid.  This one-line fix just returns an error code if FreeRTOS_socket returns an error code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.