### PR TITLE
Repair CBMC proofs for DNS and DHCP methods

### DIFF
--- a/tools/cbmc/include/cbmc.h
+++ b/tools/cbmc/include/cbmc.h
@@ -1,12 +1,45 @@
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_DHCP.h"
+#include "NetworkBufferManagement.h"
+#include "NetworkInterface.h"
+
 /*
- * CBMC models a pointer as an object id and an offset into that
- * object.  The top bits of a pointer encode the object id and the
- * remaining bits encode the offset.  This means there is a bound on
- * the maximum offset into an object in CBMC, and hence a bound on the
- * size of objects in CBMC.
- */
+  * CBMC models a pointer as an object id and an offset into that
+  * object.  The top bits of a pointer encode the object id and the
+  * remaining bits encode the offset.  This means there is a bound on
+  * the maximum offset into an object in CBMC, and hence a bound on the
+  * size of objects in CBMC.
+  */
 #define CBMC_BITS               7
 #define CBMC_MAX_OBJECT_SIZE    ( 0xFFFFFFFF >> ( CBMC_BITS + 1 ) )
+
+#define IMPLIES( a, b )    ( !( a ) || ( b ) )
+
+BaseType_t nondet_basetype();
+UBaseType_t nondet_ubasetype();
+TickType_t nondet_ticktype();
+int32_t nondet_int32();
+uint32_t nondet_uint32();
+size_t nondet_sizet();
+
+#define nondet_BaseType()    nondet_basetype()
+
+void * safeMalloc( size_t size );
+
 
 enum CBMC_LOOP_CONDITION
 {
@@ -37,19 +70,19 @@ enum CBMC_LOOP_CONDITION
 #define __CPROVER_printf2_ptr( str, exp )    { uint8_t * ValueOf_ ## str = ( uint8_t * ) ( exp ); }
 
 /*
- * An assertion that pvPortMalloc returns NULL when asked to allocate 0 bytes.
- * This assertion is used in some of the TaskPool proofs.
- */
+  * An assertion that pvPortMalloc returns NULL when asked to allocate 0 bytes.
+  * This assertion is used in some of the TaskPool proofs.
+  */
 #define __CPROVER_assert_zero_allocation()       \
     __CPROVER_assert( pvPortMalloc( 0 ) == NULL, \
                       "pvPortMalloc allows zero-allocated memory." )
 
 /*
- * A stub for pvPortMalloc that nondeterministically chooses to return
- * either NULL or an allocation of the requested space.  The stub is
- * guaranteed to return NULL when asked to allocate 0 bytes.
- * This stub is used in some of the TaskPool proofs.
- */
+  * A stub for pvPortMalloc that nondeterministically chooses to return
+  * either NULL or an allocation of the requested space.  The stub is
+  * guaranteed to return NULL when asked to allocate 0 bytes.
+  * This stub is used in some of the TaskPool proofs.
+  */
 void * pvPortMalloc( size_t xWantedSize )
 {
     if( xWantedSize == 0 )
@@ -65,7 +98,3 @@ void vPortFree( void * pv )
     ( void ) pv;
     free( pv );
 }
-
-BaseType_t nondet_basetype();
-UBaseType_t nondet_ubasetype();
-TickType_t nondet_ticktype();

--- a/tools/cbmc/patches/remove-static-in-freertos-dns.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-dns.patch
@@ -1,8 +1,20 @@
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
-index 9804543d8..361a3361b 100644
+index 480d50b..5557253 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
-@@ -122,7 +122,11 @@ static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
+@@ -114,7 +114,11 @@ static Socket_t prvCreateDNSSocket( void );
+ /*
+  * Create the DNS message in the zero copy buffer passed in the first parameter.
+  */
++#ifdef CBMC
++size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
++#else
+ static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
++#endif
+ 								   const char *pcHostName,
+ 								   TickType_t uxIdentifier );
+ 
+@@ -122,7 +126,11 @@ static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
   * Simple routine that jumps over the NAME field of a resource record.
   * It returns the number of bytes read.
   */
@@ -14,7 +26,7 @@ index 9804543d8..361a3361b 100644
  								size_t uxLength );
  
  /*
-@@ -130,7 +134,11 @@ static size_t prvSkipNameField( const uint8_t *pucByte,
+@@ -130,7 +138,11 @@ static size_t prvSkipNameField( const uint8_t *pucByte,
   * The parameter 'xExpected' indicates whether the identifier in the reply
   * was expected, and thus if the DNS cache may be updated with the reply.
   */
@@ -26,7 +38,7 @@ index 9804543d8..361a3361b 100644
  								  size_t uxBufferLength,
  								  BaseType_t xExpected );
  
-@@ -184,7 +192,11 @@ static uint32_t prvGetHostByName( const char *pcHostName,
+@@ -184,7 +196,11 @@ static uint32_t prvGetHostByName( const char *pcHostName,
  
  
  #if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
@@ -38,7 +50,19 @@ index 9804543d8..361a3361b 100644
  									size_t uxRemainingBytes,
  									char *pcName,
  									size_t uxDestLen );
-@@ -839,7 +851,11 @@ static const DNSMessage_t xDefaultPartDNSHeader =
+@@ -758,7 +774,11 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
+ }
+ /*-----------------------------------------------------------*/
+ 
++#ifdef CBMC
++size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
++#else
+ static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
++#endif
+ 								   const char *pcHostName,
+ 								   TickType_t uxIdentifier )
+ {
+@@ -838,7 +858,11 @@ static const DNSMessage_t xDefaultPartDNSHeader =
  
  #if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
  
@@ -50,7 +74,7 @@ index 9804543d8..361a3361b 100644
  									size_t uxRemainingBytes,
  									char *pcName,
  									size_t uxDestLen )
-@@ -926,7 +942,11 @@ static const DNSMessage_t xDefaultPartDNSHeader =
+@@ -932,7 +956,11 @@ static const DNSMessage_t xDefaultPartDNSHeader =
  #endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
  /*-----------------------------------------------------------*/
  
@@ -62,7 +86,7 @@ index 9804543d8..361a3361b 100644
  								size_t uxLength )
  {
  size_t uxChunkLength;
-@@ -1044,7 +1064,11 @@ size_t uxPayloadSize;
+@@ -1050,7 +1078,11 @@ size_t uxPayloadSize;
  #endif /* ipconfigUSE_NBNS */
  /*-----------------------------------------------------------*/
  

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName/DNSgetHostByName_harness.c
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName/DNSgetHostByName_harness.c
@@ -1,49 +1,94 @@
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
-#include "queue.h"
+#include "task.h"
+#include "semphr.h"
 
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
-#include "FreeRTOS_DNS.h"
-#include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_DNS.h"
+#include "FreeRTOS_DHCP.h"
+#include "NetworkBufferManagement.h"
+#include "NetworkInterface.h"
 
-/* This assumes the length of pcHostName is bounded by MAX_HOSTNAME_LEN and the size of UDPPayloadBuffer is bounded by
-MAX_REQ_SIZE. */
+#include "cbmc.h"
 
-void *safeMalloc(size_t xWantedSize) {
-	if(xWantedSize == 0) {
-		return NULL;
-	}
-	uint8_t byte;
-	return byte ? malloc(xWantedSize) : NULL;
+/****************************************************************
+ * We abstract:
+ *
+ *   All kernel task scheduling functions since we are doing
+ *   sequential verification and the sequential verification of these
+ *   sequential primitives is done elsewhere.
+ *
+ *   Many methods in the FreeRTOS TCP API in stubs/freertos_api.c
+ *
+ *   prvParseDNSReply proved memory safe elsewhere
+ *
+ *   prvCreateDNSMessage
+ *
+ * This proof assumes the length of pcHostName is bounded by
+ * MAX_HOSTNAME_LEN.  We have to bound this length because we have to
+ * bound the iterations of strcmp.
+ ****************************************************************/
+
+/****************************************************************
+ * Abstract prvParseDNSReply proved memory save in ParseDNSReply.
+ *
+ * We stub out his function to fill the payload buffer with
+ * unconstrained data and return an unconstrained size.
+ *
+ * The function under test uses only the return value of this
+ * function.
+ ****************************************************************/
+
+uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
+                           size_t xBufferLength,
+                           BaseType_t xExpected )
+{
+    uint32_t size;
+
+    __CPROVER_havoc_object( pucUDPPayloadBuffer );
+    return size;
 }
 
-/* Abstraction of FreeRTOS_GetUDPPayloadBuffer. This should be checked later. For now we are allocating a fixed sized memory of size MAX_REQ_SIZE. */
-void * FreeRTOS_GetUDPPayloadBuffer(size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks ) {
-	void *pvReturn = safeMalloc(MAX_REQ_SIZE);
-	return pvReturn;
+
+/****************************************************************
+ * Abstract prvCreateDNSMessage
+ *
+ * This function writes a header, a hostname, and a constant amount of
+ * data into the payload buffer, and returns the amount of data
+ * written.  This abstraction just fills the entire buffer with
+ * unconstrained data and returns and unconstrained length.
+ ****************************************************************/
+
+size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
+                            const char * pcHostName,
+                            TickType_t uxIdentifier )
+{
+    __CPROVER_havoc_object( pucUDPPayloadBuffer );
+    size_t size;
+    return size;
 }
 
-/* Abstraction of FreeRTOS_socket. This abstraction allocates a memory of size Socket_t. */
-Socket_t FreeRTOS_socket( BaseType_t xDomain, BaseType_t xType, BaseType_t xProtocol ) {
-	Socket_t xSocket = safeMalloc(sizeof(Socket_t)); /* Replaced malloc by safeMalloc */
-	return xSocket;
-}
+/****************************************************************
+ * The proof for FreeRTOS_gethostbyname.
+ ****************************************************************/
 
-/* This function only uses the return value of prvParseDNSReply. Hence it returns an unconstrained uint32 value */
-uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-			   size_t xBufferLength,
-			   BaseType_t xExpected ) {}
+void harness()
+{
+    size_t len;
 
-void harness() {
-	size_t len;
-	__CPROVER_assume(len >= 0 && len <= MAX_HOSTNAME_LEN);
-	char *pcHostName = safeMalloc(len); /* Replaced malloc by safeMalloc */
-	if (len && pcHostName) {
-		pcHostName[len-1] = NULL;
-	}
-	if (pcHostName) { /* Guarding against NULL pointer */
-		FreeRTOS_gethostbyname(pcHostName);
-	}
+    __CPROVER_assume( len <= MAX_HOSTNAME_LEN );
+    char * pcHostName = safeMalloc( len );
+
+    __CPROVER_assume( len > 0 ); /* prvProcessDNSCache strcmp */
+    __CPROVER_assume( pcHostName != NULL );
+    pcHostName[ len - 1 ] = NULL;
+    FreeRTOS_gethostbyname( pcHostName );
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName/Makefile.json
@@ -1,29 +1,34 @@
 {
   "ENTRY": "DNSgetHostByName",
+
   ################################################################
-	# This configuration sets callback to 0. It also sets MAX_HOSTNAME_LEN to 10 and MAX_REQ_SIZE to 50 for performance issues.
+  # This configuration sets callback to 0.
+  # It also sets MAX_HOSTNAME_LEN to 10 to bound strcmp.
   # According to the specification MAX_HOST_NAME is upto 255.
+
   "callback": 0,
   "MAX_HOSTNAME_LEN": 10,
-  "MAX_REQ_SIZE": 50,
   "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
+
   "CBMCFLAGS":
   [
     "--unwind 1",
     "--unwindset prvProcessDNSCache.0:5,prvGetHostByName.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.0:{HOSTNAME_UNWIND},prvCreateDNSMessage.1:{HOSTNAME_UNWIND},strlen.0:{HOSTNAME_UNWIND},__builtin___strcpy_chk.0:{HOSTNAME_UNWIND},strcmp.0:{HOSTNAME_UNWIND},strcpy.0:{HOSTNAME_UNWIND}",
-    "--nondet-static"
+    "--nondet-static",
+    "--verbosity 10"
   ],
+
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
-    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
-    "$(FREERTOS)/freertos_kernel/tasks.goto"
+    "$(FREERTOS)/tools/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/freertos_api.goto",
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto"
   ],
+
   "DEF":
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
-    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
-    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
-  ],
-  "OPT" : "-m32"
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
+  ]
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName/cbmc-viewer.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName/cbmc-viewer.json
@@ -1,0 +1,9 @@
+{ "expected-missing-functions":
+  [
+    "vLoggingPrintf",
+    "xApplicationGetRandomNumber",
+    "xTaskGetTickCount"
+  ],
+  "proof-name": "DNSgetHostByName",
+  "proof-root": "tools/cbmc/proofs"
+}

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/Makefile.json
@@ -5,7 +5,6 @@
   # According to the specification MAX_HOST_NAME is upto 255.
   "callback": 1,
   "MAX_HOSTNAME_LEN": 10,
-  "MAX_REQ_SIZE": 50,
   "HOSTNAME_UNWIND": "__eval {MAX_HOSTNAME_LEN} + 1",
   "CBMCFLAGS":
   [
@@ -16,14 +15,16 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/freertos_api.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.goto",
-    "$(FREERTOS)/freertos_kernel/tasks.goto"
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto"
   ],
   "DEF":
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
     "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
-    "MAX_REQ_SIZE={MAX_REQ_SIZE}"
-  ],
-  "OPT" : "-m32"
+    # This value is defined only when ipconfigUSE_DNS_CACHE==1
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
+  ]
 }

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_a/cbmc-viewer.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_a/cbmc-viewer.json
@@ -1,0 +1,13 @@
+{ "expected-missing-functions":
+  [
+    "vLoggingPrintf",
+    "xApplicationGetRandomNumber",
+    "vListInsertEnd",
+    "vTaskSetTimeOutState",
+    "vTaskSuspendAll",
+    "xTaskGetTickCount",
+    "xTaskResumeAll"
+  ],
+  "proof-name": "DNSgetHostByName_a",
+  "proof-root": "tools/cbmc/proofs"
+}

--- a/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
+++ b/tools/cbmc/proofs/DNS/DNSgetHostByName_cancel/Makefile.json
@@ -22,7 +22,8 @@
   "DEF":
   [
     "ipconfigDNS_USE_CALLBACKS={callback}",
-    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}"
-  ],
-  "OPT" : "-m32"
+    "MAX_HOSTNAME_LEN={MAX_HOSTNAME_LEN}",
+    # This value is defined only when ipconfigUSE_DNS_CACHE==1
+    "ipconfigDNS_CACHE_NAME_LENGTH=254"
+  ]
 }

--- a/tools/cbmc/proofs/ProcessDHCPReplies/Makefile.json
+++ b/tools/cbmc/proofs/ProcessDHCPReplies/Makefile.json
@@ -7,22 +7,24 @@
   "ENTRY": "ProcessDHCPReplies",
 
 ################################################################
-# Buffer size
-# Reasonable sizes are  BUFFER_SIZE > 241 = sizeof(DHCHMessage_t))
-# Sizes smaller than this causes CBMC to fail in simplify_byte_extract
-  "BUFFER_SIZE": 300,
+# Buffer header: sizeof(DHCPMessage_t) = 241
+# Buffer header: sizeof(DHCPMessage_IPv4_t) = 240
+  "BUFFER_HEADER": 240,
 
 ################################################################
-# Buffer header: sizeof(DHCHMessage_t) = 241
-  "BUFFER_HEADER": 241,
+# Buffer size
+# Reasonable sizes are  BUFFER_SIZE > BUFFER_HEADER
+# Sizes smaller than this causes CBMC to fail in simplify_byte_extract
+  "BUFFER_SIZE": 252,
 
 ################################################################
 # Buffer payload
-  "BUFFER_PAYLOAD": "__eval 1 if {BUFFER_SIZE} <= {BUFFER_HEADER} else {BUFFER_SIZE} - {BUFFER_HEADER} + 2",
+  "BUFFER_PAYLOAD": "__eval 1 if {BUFFER_SIZE} <= {BUFFER_HEADER} else {BUFFER_SIZE} - {BUFFER_HEADER} + 1",
 
 ################################################################
 
   "CBMCFLAGS": [
+      # "--nondet-static",
       "--unwind 1",
       "--unwindset memcmp.0:7,prvProcessDHCPReplies.0:{BUFFER_PAYLOAD}"
   ],
@@ -30,6 +32,8 @@
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/freertos_api.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/portable/BufferManagement/BufferAllocation_2.goto",
     "$(FREERTOS)/freertos_kernel/event_groups.goto",
@@ -38,6 +42,7 @@
 
   "DEF":
   [
-    "BUFFER_SIZE={BUFFER_SIZE}"
+    "CBMC_DHCPMESSAGE_HEADER_SIZE={BUFFER_HEADER}",
+    "CBMC_FREERTOS_RECVFROM_BUFFER_BOUND={BUFFER_SIZE}"
   ]
 }

--- a/tools/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
+++ b/tools/cbmc/proofs/ProcessDHCPReplies/ProcessDHCPReplies_harness.c
@@ -1,11 +1,9 @@
 /* Standard includes. */
 #include <stdint.h>
-#include <stdio.h>
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"
-#include "queue.h"
 #include "semphr.h"
 
 /* FreeRTOS+TCP includes. */
@@ -13,52 +11,27 @@
 #include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
 #include "FreeRTOS_UDP_IP.h"
-#include "FreeRTOS_TCP_IP.h"
 #include "FreeRTOS_DHCP.h"
-#include "NetworkInterface.h"
-#include "NetworkBufferManagement.h"
 #include "FreeRTOS_ARP.h"
-#include "FreeRTOS_TCP_WIN.h"
 
-// Used to model FreeRTOS_recvfrom returning an arbitrary buffer
-char read_buffer[BUFFER_SIZE];
+
+/****************************************************************
+ * Signature of function under test
+ ****************************************************************/
 
 BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
 
-// Stub
-int32_t FreeRTOS_recvfrom(
-  Socket_t xSocket, void *pvBuffer, size_t xBufferLength,
-  BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress,
-  socklen_t *pxSourceAddressLength )
+/****************************************************************
+ * The proof for FreeRTOS_gethostbyname.
+ ****************************************************************/
+
+void harness()
 {
-  __CPROVER_assert(xFlags & FREERTOS_ZERO_COPY, "I can only do ZERO_COPY");
+    /* Omitting model of an unconstrained xDHCPData because xDHCPData is */
+    /* the source of uninitialized data only on line 647 to set a */
+    /* transaction id is an outgoing message */
 
-  // Choose buffer size
-  size_t offset;
-  size_t buffer_size = BUFFER_SIZE - offset;
-  char *buffer = read_buffer + offset;
-  __CPROVER_assume(offset <= BUFFER_SIZE);
+    BaseType_t xExpectedMessageType;
 
-  // Choose buffer contents
-  // __CPROVER_havoc_object may not interact well with simplifier
-  char temporary[BUFFER_SIZE];
-  memcpy(read_buffer, temporary, BUFFER_SIZE);
-
-  *((char **)pvBuffer) = buffer;
-  return buffer_size;
-}
-
-// Stub
-void FreeRTOS_ReleaseUDPPayloadBuffer( void *pvBuffer )
-{
-  // no-op
-}
-
-void harness() {
-  // Omitting model of an unconstrained xDHCPData because xDHCPData is
-  // the source of uninitialized data only on line 647 to set a
-  // transaction id is an outgoing message
-
-  BaseType_t xExpectedMessageType;
-  prvProcessDHCPReplies(xExpectedMessageType);
+    prvProcessDHCPReplies( xExpectedMessageType );
 }

--- a/tools/cbmc/proofs/ProcessDHCPReplies/cbmc-viewer.json
+++ b/tools/cbmc/proofs/ProcessDHCPReplies/cbmc-viewer.json
@@ -1,0 +1,7 @@
+{ "expected-missing-functions":
+  [
+    "vLoggingPrintf"
+  ],
+  "proof-name": "ProcessDHCPReplies",
+  "proof-root": "tools/cbmc/proofs"
+}

--- a/tools/cbmc/proofs/ReadNameField/ReadNameField_harness.c
+++ b/tools/cbmc/proofs/ReadNameField/ReadNameField_harness.c
@@ -30,6 +30,29 @@ size_t prvReadNameField( const uint8_t *pucByte,
 			 size_t uxDestLen );
 
 /****************************************************************
+ * The function under test is not defined in all configurations
+ ****************************************************************/
+
+#if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )  
+
+/* prvReadNameField is defined in this configuration */
+
+#else
+
+/* prvReadNameField is not defined in this configuration, stub it. */
+
+size_t prvReadNameField( const uint8_t *pucByte,
+			 size_t uxRemainingBytes,
+			 char *pcName,
+			 size_t uxDestLen )
+{
+  return 0;
+}
+
+#endif
+
+
+/****************************************************************
  * Proof of prvReadNameField function contract
  ****************************************************************/
 

--- a/tools/cbmc/stubs/cbmc.c
+++ b/tools/cbmc/stubs/cbmc.c
@@ -1,0 +1,12 @@
+#include "cbmc.h"
+
+/****************************************************************
+ * Model a malloc that can fail (CBMC malloc does not fail) and
+ * check that CBMC can model an object of the requested size.
+ ****************************************************************/
+
+void * safeMalloc( size_t size )
+{
+    __CPROVER_assert( size < CBMC_MAX_OBJECT_SIZE, "safeMalloc size too big" );
+    return nondet_bool() ? NULL : malloc( size );
+}

--- a/tools/cbmc/stubs/freertos_api.c
+++ b/tools/cbmc/stubs/freertos_api.c
@@ -1,0 +1,293 @@
+/* Standard includes. */
+#include <stdint.h>
+#include <stdio.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "queue.h"
+#include "semphr.h"
+
+/* FreeRTOS+TCP includes. */
+#include "FreeRTOS_UDP_IP.h"
+#include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
+#include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_DNS.h"
+#include "NetworkBufferManagement.h"
+
+#include "cbmc.h"
+
+/****************************************************************
+ * This is a collection of abstractions of methods in the FreeRTOS TCP
+ * API.  The abstractions simply perform minimal validation of
+ * function arguments, and return unconstrained values of the
+ * appropriate type.
+ ****************************************************************/
+
+/****************************************************************
+ * Abstract FreeRTOS_socket.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/socket.html
+ *
+ * We stub out this function to do nothing but allocate space for a
+ * socket containing unconstrained data or return an error.
+ ****************************************************************/
+
+Socket_t FreeRTOS_socket( BaseType_t xDomain,
+                          BaseType_t xType,
+                          BaseType_t xProtocol )
+{
+    return nondet_bool() ?
+           FREERTOS_INVALID_SOCKET : malloc( sizeof( Socket_t ) );
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_setsockopt.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/setsockopt.html
+ ****************************************************************/
+
+BaseType_t FreeRTOS_setsockopt( Socket_t xSocket,
+                                int32_t lLevel,
+                                int32_t lOptionName,
+                                const void * pvOptionValue,
+                                size_t uxOptionLength )
+{
+    __CPROVER_assert( xSocket != NULL,
+                      "FreeRTOS precondition: xSocket != NULL" );
+    __CPROVER_assert( pvOptionValue != NULL,
+                      "FreeRTOS precondition: pvOptionValue != NULL" );
+    return nondet_BaseType();
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_closesocket.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/close.html
+ ****************************************************************/
+
+BaseType_t FreeRTOS_closesocket( Socket_t xSocket )
+{
+    __CPROVER_assert( xSocket != NULL,
+                      "FreeRTOS precondition: xSocket != NULL" );
+    return nondet_BaseType();
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_bind.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/bind.html
+ ****************************************************************/
+
+BaseType_t FreeRTOS_bind( Socket_t xSocket,
+                          struct freertos_sockaddr * pxAddress,
+                          socklen_t xAddressLength )
+{
+    __CPROVER_assert( xSocket != NULL,
+                      "FreeRTOS precondition: xSocket != NULL" );
+    __CPROVER_assert( pxAddress != NULL,
+                      "FreeRTOS precondition: pxAddress != NULL" );
+    return nondet_BaseType();
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_inet_addr.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/inet_addr.html
+ ****************************************************************/
+
+uint32_t FreeRTOS_inet_addr( const char * pcIPAddress )
+{
+    __CPROVER_assert( pcIPAddress != NULL,
+                      "FreeRTOS precondition: pcIPAddress != NULL" );
+    return nondet_uint32();
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_recvfrom.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/recvfrom.html
+ *
+ * We stub out this function to do nothing but allocate a buffer of
+ * unconstrained size containing unconstrained data and return the
+ * size (or return the size 0 if the allocation fails).
+ ****************************************************************/
+
+int32_t FreeRTOS_recvfrom( Socket_t xSocket,
+                           void * pvBuffer,
+                           size_t uxBufferLength,
+                           BaseType_t xFlags,
+                           struct freertos_sockaddr * pxSourceAddress,
+                           socklen_t * pxSourceAddressLength )
+
+{
+    /****************************************************************
+     * "If the zero copy calling semantics are used (the ulFlasg
+     * parameter does not have the FREERTOS_ZERO_COPY bit set) then
+     * pvBuffer does not point to a buffer and xBufferLength is not
+     * used."  This is from the documentation.
+     ****************************************************************/
+    __CPROVER_assert( xFlags & FREERTOS_ZERO_COPY, "I can only do ZERO_COPY" );
+
+    __CPROVER_assert( pvBuffer != NULL,
+                      "FreeRTOS precondition: pvBuffer != NULL" );
+
+    /****************************************************************
+     * TODO: We need to check this out.
+     *
+     * The code calls recvfrom with these parameters NULL, it is not
+     * clear from the documentation that this is allowed.
+     ****************************************************************/
+    #if 0
+        __CPROVER_assert( pxSourceAddress != NULL,
+                          "FreeRTOS precondition: pxSourceAddress != NULL" );
+        __CPROVER_assert( pxSourceAddressLength != NULL,
+                          "FreeRTOS precondition: pxSourceAddress != NULL" );
+    #endif
+
+    size_t xBufferSize;
+    __CPROVER_assume( xBufferSize < CBMC_MAX_OBJECT_SIZE );
+
+    /****************************************************************
+     * TODO: We need to make this lower bound explicit in the Makefile.json
+     *
+     * DNSMessage_t is a typedef in FreeRTOS_DNS.c
+     * sizeof(DNSMessage_t) = 6 * sizeof(uint16_t)
+     ****************************************************************/
+    __CPROVER_assume( xBufferSize >= 6 * sizeof( uint16_t ) );
+
+    #ifdef CBMC_FREERTOS_RECVFROM_BUFFER_BOUND
+        __CPROVER_assume( xBufferSize <= CBMC_FREERTOS_RECVFROM_BUFFER_BOUND );
+    #endif
+
+    *( ( uint8_t ** ) pvBuffer ) = safeMalloc( xBufferSize );
+    return *( ( uint8_t ** ) pvBuffer ) == NULL ? 0 : xBufferSize;
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_recvfrom.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/sendto.html
+ ****************************************************************/
+
+int32_t FreeRTOS_sendto( Socket_t xSocket,
+                         const void * pvBuffer,
+                         size_t uxTotalDataLength,
+                         BaseType_t xFlags,
+                         const struct freertos_sockaddr * pxDestinationAddress,
+                         socklen_t xDestinationAddressLength )
+{
+    __CPROVER_assert( xSocket != NULL,
+                      "FreeRTOS precondition: xSocket != NULL" );
+    __CPROVER_assert( pvBuffer != NULL,
+                      "FreeRTOS precondition: pvBuffer != NULL" );
+    __CPROVER_assert( pxDestinationAddress != NULL,
+                      "FreeRTOS precondition: pxDestinationAddress != NULL" );
+    return nondet_int32();
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_GetUDPPayloadBuffer
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_UDP/API/FreeRTOS_GetUDPPayloadBuffer.html
+ *
+ * We stub out this function to do nothing but allocate a buffer of
+ * unconstrained size containing unconstrained data and return a
+ * pointer to the buffer (or NULL).
+ ****************************************************************/
+
+void * FreeRTOS_GetUDPPayloadBuffer( size_t xRequestedSizeBytes,
+                                     TickType_t xBlockTimeTicks )
+{
+    size_t size;
+
+    __CPROVER_assume( size < CBMC_MAX_OBJECT_SIZE );
+    return safeMalloc( size );
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_GetUDPPayloadBuffer
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/FreeRTOS_ReleaseUDPPayloadBuffer.html
+ ****************************************************************/
+
+void FreeRTOS_ReleaseUDPPayloadBuffer( void * pvBuffer )
+{
+    __CPROVER_assert( pvBuffer != NULL,
+                      "FreeRTOS precondition: pvBuffer != NULL" );
+    free( pvBuffer );
+}
+
+/****************************************************************
+ * Abstract pxGetNetworkBufferWithDescriptor.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/pxGetNetworkBufferWithDescriptor.html
+ *
+ * The real allocator take buffers off a list.
+ ****************************************************************/
+
+NetworkBufferDescriptor_t * pxGetNetworkBufferWithDescriptor( size_t xRequestedSizeBytes,
+                                                              TickType_t xBlockTimeTicks )
+{
+    __CPROVER_assert(
+        xRequestedSizeBytes + ipBUFFER_PADDING < CBMC_MAX_OBJECT_SIZE,
+        "pxGetNetworkBufferWithDescriptor: request too big" );
+
+    NetworkBufferDescriptor_t * desc = safeMalloc( sizeof( *desc ) );
+
+    if( desc != NULL )
+    {
+        size_t size;
+        __CPROVER_assume( size < CBMC_MAX_OBJECT_SIZE );
+        desc->pucEthernetBuffer = safeMalloc( size );
+        desc->xDataLength = size;
+
+        __CPROVER_assume(
+            desc->xDataLength <= xRequestedSizeBytes + ipBUFFER_PADDING );
+        __CPROVER_assume(
+            IMPLIES( desc->pucEthernetBuffer == NULL, desc->xDataLength == 0 ) );
+    }
+
+    return desc;
+}
+
+/****************************************************************
+ * Abstract pxGetNetworkBufferWithDescriptor.
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/vReleaseNetworkBufferAndDescriptor.html
+ ****************************************************************/
+
+void vReleaseNetworkBufferAndDescriptor( NetworkBufferDescriptor_t * const pxNetworkBuffer )
+{
+    __CPROVER_assert( pxNetworkBuffer != NULL,
+                      "Precondition: pxNetworkBuffer != NULL" );
+
+    if( pxNetworkBuffer->pucEthernetBuffer != NULL )
+    {
+        free( pxNetworkBuffer->pucEthernetBuffer );
+    }
+
+    free( pxNetworkBuffer );
+}
+
+/****************************************************************
+ * Abstract FreeRTOS_GetAddressConfiguration
+ * https://www.freertos.org/FreeRTOS-Plus/FreeRTOS_Plus_TCP/API/FreeRTOS_GetAddressConfiguration.html
+ ****************************************************************/
+void FreeRTOS_GetAddressConfiguration( uint32_t * pulIPAddress,
+                                       uint32_t * pulNetMask,
+                                       uint32_t * pulGatewayAddress,
+                                       uint32_t * pulDNSServerAddress )
+{
+    if( pulIPAddress != NULL )
+    {
+        *pulIPAddress = nondet_unint32();
+    }
+
+    if( pulNetMask != NULL )
+    {
+        *pulNetMask = nondet_unint32();
+    }
+
+    if( pulGatewayAddress != NULL )
+    {
+        *pulGatewayAddress = nondet_unint32();
+    }
+
+    if( pulDNSServerAddress != NULL )
+    {
+        *pulDNSServerAddress = nondet_unint32();
+    }
+}
+
+/****************************************************************/


### PR DESCRIPTION
This pull request fixes the CBMC proofs for

* `DNSgetHostByName`
* `DNSgetHostByName_a`
* `DNSgetHostByName_cancel`
* `ProcessDHCPReplies`
* `ReadNameField`

Warning: This pull request includes the pull request https://github.com/htibosch/amazon-freertos/pull/13 that modifies FreeRTOS_DHCP.c, and hence merging this pull request depends on merging that pull request first.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.