### PR TITLE
Repair fix to prvProcessDHCPReplies memory safety errors.

### DIFF
--- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
+++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
@@ -718,8 +718,6 @@ const uint32_t ulMandatoryOptions = 2UL; /* DHCP server address, and the correct
 						( void ) memcpy( &( ulParameter ),
 										&( pucByte[ uxIndex ] ),
 										( size_t ) sizeof( ulParameter ) );
-						/* skip over the parameter */
-						uxIndex += sizeof( ulParameter );
 					}
 					else
 					{
@@ -778,10 +776,13 @@ const uint32_t ulMandatoryOptions = 2UL; /* DHCP server address, and the correct
 
 						case dhcpIPv4_DNS_SERVER_OPTIONS_CODE :
 
-							/* ulProcessed is not incremented in this case
-							because the DNS server is not essential.  Only the
-							first DNS server address is taken. */
-							EP_IPv4_SETTINGS.ulDNSServerAddress = ulParameter;
+						        if( uxLength == sizeof( uint32_t ) )
+						        {
+								/* ulProcessed is not incremented in this case
+								because the DNS server is not essential.  Only the
+								first DNS server address is taken. */
+								EP_IPv4_SETTINGS.ulDNSServerAddress = ulParameter;
+                                                        }
 							break;
 
 						case dhcpIPv4_SERVER_IP_ADDRESS_OPTION_CODE :


### PR DESCRIPTION
Remove code skipping over ulParameter (it is skipped at the bottom of
loop: uxLength includes the size of ulParameter).

Add a uxLength check before copying ulParameter into a struct member.

I've confirmed that the CBMC memory safety proof for ProcessDHCPReplies works after this patch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.