### PR TITLE
Repair CBMC DHCPProcess proof.

### DIFF
--- a/tools/cbmc/patches/remove-static-in-freertos-dhcp.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-dhcp.patch
@@ -1,8 +1,20 @@
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
-index 650499f80..26e732f03 100644
+index 04b0487..d6e74a9 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
-@@ -179,7 +179,11 @@ static void prvSendDHCPDiscover( void );
+@@ -156,7 +156,11 @@ struct xDHCPMessage_IPv4
+ typedef struct xDHCPMessage_IPv4 DHCPMessage_IPv4_t;
+ 
+ /* The UDP socket used for all incoming and outgoing DHCP traffic. */
++#ifdef CBMC
++Socket_t xDHCPSocket;
++#else
+ static Socket_t xDHCPSocket;
++#endif
+ 
+ #if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+ 	/* Define the Link Layer IP address: 169.254.x.x */
+@@ -179,7 +183,11 @@ static void prvSendDHCPDiscover( void );
  /*
   * Interpret message received on the DHCP socket.
   */
@@ -14,7 +26,19 @@ index 650499f80..26e732f03 100644
  
  /*
   * Generate a DHCP request packet, and send it on the DHCP socket.
-@@ -223,7 +227,11 @@ static void prvCloseDHCPSocket( void );
+@@ -204,7 +212,11 @@ static uint8_t *prvCreatePartDHCPMessage( struct freertos_sockaddr *pxAddress,
+ /*
+  * Create the DHCP socket, if it has not been created already.
+  */
++#ifdef CBMC
++void prvCreateDHCPSocket( void );
++#else
+ static void prvCreateDHCPSocket( void );
++#endif
+ 
+ /*
+  * Close the DHCP socket.
+@@ -223,7 +235,11 @@ static void prvCloseDHCPSocket( void );
  /*-----------------------------------------------------------*/
  
  /* Hold information in between steps in the DHCP state machine. */
@@ -26,7 +50,7 @@ index 650499f80..26e732f03 100644
  
  /*-----------------------------------------------------------*/
  
-@@ -623,7 +631,11 @@ static void prvInitialiseDHCP( void )
+@@ -623,7 +639,11 @@ static void prvInitialiseDHCP( void )
  }
  /*-----------------------------------------------------------*/
  

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/DHCPProcess_harness.c
@@ -1,101 +1,102 @@
 /*
- * FreeRTOS memory safety proofs with CBMC.
- * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
- *
- * Permission is hereby granted, free of charge, to any person
- * obtaining a copy of this software and associated documentation
- * files (the "Software"), to deal in the Software without
- * restriction, including without limitation the rights to use, copy,
- * modify, merge, publish, distribute, sublicense, and/or sell copies
- * of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be
- * included in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * http://aws.amazon.com/freertos
- * http://www.FreeRTOS.org
- */
+  * FreeRTOS memory safety proofs with CBMC.
+  * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+  *
+  * Permission is hereby granted, free of charge, to any person
+  * obtaining a copy of this software and associated documentation
+  * files (the "Software"), to deal in the Software without
+  * restriction, including without limitation the rights to use, copy,
+  * modify, merge, publish, distribute, sublicense, and/or sell copies
+  * of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be
+  * included in all copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+  * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  * SOFTWARE.
+  *
+  * http://aws.amazon.com/freertos
+  * http://www.FreeRTOS.org
+  */
 
+/* Standard includes. */
 #include <stdint.h>
 
 /* FreeRTOS includes. */
 #include "FreeRTOS.h"
 #include "task.h"
+#include "semphr.h"
 
 /* FreeRTOS+TCP includes. */
 #include "FreeRTOS_IP.h"
+#include "FreeRTOS_Sockets.h"
 #include "FreeRTOS_IP_Private.h"
+#include "FreeRTOS_UDP_IP.h"
 #include "FreeRTOS_DHCP.h"
+#include "FreeRTOS_ARP.h"
 
-/*
- * CBMC automatically unwinds strlen on a fixed string
- */
-const char * pcApplicationHostnameHook(void) {
-  return "hostname";
-}
+/* Static members defined in FreeRTOS_DHCP.c */
+extern DHCPData_t xDHCPData;
+extern Socket_t xDHCPSocket;
+void prvCreateDHCPSocket();
 
-/*
- * This stub allows us to overcome the unwinding error obtained
- * in the do-while loop within function prvCreatePartDHCPMessage.
- * The behaviour is similar to the original function, but failed allocations
- * are not considered here (this is a safe assumption that avoids the error)
- */
-void *FreeRTOS_GetUDPPayloadBuffer( size_t xRequestedSizeBytes, TickType_t xBlockTimeTicks )
+/* Static member defined in freertos_api.c */
+#ifdef CBMC_GETNETWORKBUFFER_FAILURE_BOUND
+    extern uint32_t GetNetworkBuffer_failure_count;
+#endif
+
+/****************************************************************
+ * The signature of the function under test.
+ ****************************************************************/
+
+void vDHCPProcess( BaseType_t xReset );
+
+/****************************************************************
+ * Abstract prvProcessDHCPReplies proved memory safe in ProcessDHCPReplies.
+ ****************************************************************/
+
+BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
 {
-  NetworkBufferDescriptor_t xNetworkBuffer;
-  void *pvReturn;
-
-  xNetworkBuffer.xDataLength = ipUDP_PAYLOAD_OFFSET_IPv4 + xRequestedSizeBytes;
-  xNetworkBuffer.pucEthernetBuffer = malloc( xNetworkBuffer.xDataLength );
-  pvReturn = (void *) &( xNetworkBuffer.pucEthernetBuffer[ ipUDP_PAYLOAD_OFFSET_IPv4 ] );
-  return pvReturn;
+    return nondet_BaseType();
 }
 
-/*
- * We stub out FreeRTOS_recvfrom to do nothing but return a buffer of
- * arbitrary size (but size at most BUFFER_SIZE) containing arbitrary
- * data.  We need to bound the size of the buffer in order to bound
- * the number of iterations of the loop prvProcessDHCPReplies.0 that
- * iterates over the buffer contents.  The bound BUFFER_SIZE is chosen
- * to be large enough to ensure complete code coverage, and small
- * enough to ensure CBMC terminates within a reasonable amount of
- * time.
- */
-int32_t FreeRTOS_recvfrom(
-  Socket_t xSocket, void *pvBuffer, size_t xBufferLength,
-  BaseType_t xFlags, struct freertos_sockaddr *pxSourceAddress,
-  socklen_t *pxSourceAddressLength )
-{
-  __CPROVER_assert(xFlags & FREERTOS_ZERO_COPY, "I can only do ZERO_COPY");
+/****************************************************************
+ * The proof of vDHCPProcess
+ ****************************************************************/
 
-  size_t xBufferSize;
-  /* A DHCP message (min. size 241B) is preceded by the IP buffer padding (10B) and the UDP payload (42B) */
-  __CPROVER_assume(xBufferSize >= ipBUFFER_PADDING + ipUDP_PAYLOAD_OFFSET_IPv4);
-  /* The last field of a DHCP message (Options) is variable in length, but 6 additional bytes are enough */
-  /* to obtain maximum coverage with this proof. Hence, we have BUFFER_SIZE=299 */
-  __CPROVER_assume(xBufferSize <= BUFFER_SIZE);
-
-  /* The buffer gets allocated and we set the pointer past the UDP payload (i.e., start of DHCP message) */
-  *((char **)pvBuffer) = malloc(xBufferSize) + ipBUFFER_PADDING + ipUDP_PAYLOAD_OFFSET_IPv4;
-
-  return xBufferSize - ipUDP_PAYLOAD_OFFSET_IPv4 - ipBUFFER_PADDING;
-}
-
-/*
- * The harness test proceeds to call DHCPProcess with an unconstrained value
- */
 void harness()
 {
-  BaseType_t xReset;
-  vDHCPProcess( xReset );
+    BaseType_t xReset;
+
+    /****************************************************************
+     * Initialize the counter used to bound the number of times
+     * GetNetworkBufferWithDescriptor can fail.
+     ****************************************************************/
+
+    #ifdef CBMC_GETNETWORKBUFFER_FAILURE_BOUND
+        GetNetworkBuffer_failure_count = 0;
+    #endif
+
+    /****************************************************************
+     * Assume a valid socket in most states of the DHCP state machine.
+     *
+     * The socket is created in the eWaitingSendFirstDiscover state.
+     * xReset==True resets the state to eWaitingSendFirstDiscover.
+     ****************************************************************/
+
+    if( !( ( xDHCPData.eDHCPState == eWaitingSendFirstDiscover ) ||
+           ( xReset != pdFALSE ) ) )
+    {
+        prvCreateDHCPSocket();
+        __CPROVER_assume( xDHCPSocket != NULL );
+    }
+
+    vDHCPProcess( xReset );
 }

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/Makefile.json
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/Makefile.json
@@ -28,18 +28,29 @@
 
 {
   "ENTRY": "DHCPProcess",
-  "CBMCFLAGS": "--unwind 4 --unwindset strlen.0:11,memcmp.0:7,prvProcessDHCPReplies.0:8 --nondet-static",
+
+  # Minimal buffer size for maximum coverage, see harness for details.
+  "BUFFER_SIZE": 299,
+
+  # The number of times GetNetworkBufferWithDescriptor can be allowed to fail
+  # (plus 1).
+  "FAILURE_BOUND": 2,
+
+  "CBMCFLAGS": "--unwind 4 --unwindset strlen.0:11,memcmp.0:7,prvProcessDHCPReplies.0:8,prvCreatePartDHCPMessage.0:{FAILURE_BOUND} --nondet-static --flush",
   "OBJS":
   [
     "$(ENTRY)_harness.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/cbmc.goto",
+    "$(FREERTOS)/tools/cbmc/stubs/freertos_api.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.goto",
     "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_IP.goto",
-    "$(FREERTOS)/freertos_kernel/tasks.goto"
+    "$(FREERTOS)/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_ARP.goto"
   ],
-# Minimal buffer size for maximum coverage, see harness for details.
-  "BUFFER_SIZE": 299,
+
   "DEF":
   [
-    "BUFFER_SIZE={BUFFER_SIZE}"
+    "BUFFER_SIZE={BUFFER_SIZE}",
+    "CBMC_REQUIRE_NETWORKBUFFER_ETHERNETBUFFER_NONNULL=1",
+    "CBMC_GETNETWORKBUFFER_FAILURE_BOUND={FAILURE_BOUND}"
   ]
 }

--- a/tools/cbmc/proofs/DHCP/DHCPProcess/cbmc-viewer.json
+++ b/tools/cbmc/proofs/DHCP/DHCPProcess/cbmc-viewer.json
@@ -1,0 +1,16 @@
+{ "expected-missing-functions":
+  [
+    "vPortEnterCritical",
+    "vPortExitCritical",
+    "vSocketBind",
+    "vSocketClose",
+    "vTaskSetTimeOutState",
+    "xTaskGetTickCount",
+    "xTaskGetCurrentTaskHandle",
+    "xQueueGenericSend",
+    "xApplicationGetRandomNumber",
+    "vLoggingPrintf"
+  ],
+  "proof-name": "DHCPProcess",
+  "proof-root": "tools/cbmc/proofs"
+}


### PR DESCRIPTION
This repairs the CBMC memory safety proof for vDHCPProcess.

This completes the revision of proofs for this branch.  I have verified that all proofs repaired for this branch still work.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.