### PR TITLE
Add CBMC include path windows2 containing Windows.h

### DIFF
--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -64,7 +64,8 @@
         "$(FREERTOS)/libraries/3rdparty/jsmn",
 
         "$(FREERTOS)/tools/cbmc/include",
-        "$(FREERTOS)/tools/cbmc/windows"
+        "$(FREERTOS)/tools/cbmc/windows",
+        "$(FREERTOS)/tools/cbmc/windows2"
     ],
 
     "CBMCFLAGS ": [


### PR DESCRIPTION
This patch adds an include path tools/cbmc/windows2 that includes an empty Windows.h header file.

The FreeRTOS project now refers to the file by the names windows.h and Windows.h, and this works because filenames are case insensitive on Windows, but not on Linux where the proofs are checked in continuous integration.  The include path tools/cbmc/windows has had an empty windows.h for years, and adding Windows.h to the same folder will cause one of windows.h and Windows.h to be lost when using git on Windows.  So this patch adds a second include path to distinguish the two empty files with "different" but "indistinguishable" names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.