### PR TITLE
Remove MBEDTLS_CONFIG_FILE from CBMC proof Makefile

### DIFF
--- a/tools/cbmc/proofs/MakefileCommon.json
+++ b/tools/cbmc/proofs/MakefileCommon.json
@@ -4,7 +4,6 @@
 
     "DEF ": [
 	"CONFIG_MEDTLS_USE_AFR_MEMORY",
-	"MBEDTLS_CONFIG_FILE=\"aws_mbedtls_config.h\"",
 	"WIN32",
 	"WINVER=0x400",
 	"_CONSOLE",
@@ -81,4 +80,3 @@
         "$(FREERTOS)/freertos_kernel/queue.c"
     ]
 }
-


### PR DESCRIPTION
Fix the OTA CBMC proof by removing a define from the CBMC proof Makefile.

This proof runs just fine under windows.  I suspect the problem is that the line 
```
	"MBEDTLS_CONFIG_FILE=\"aws_mbedtls_config.h\"",`
```
is used in an `#include MBEDTLS_CONFIG_FILE` and escaping in linux bash versus escaping in windows cmd is doing different things to the quotes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.