### PR TITLE
Update CBMC patches to apply to code run though uncrustify.

### DIFF
--- a/tools/cbmc/patches/0002-Change-FreeRTOS_IP_Private.h-union-to-struct.patch
+++ b/tools/cbmc/patches/0002-Change-FreeRTOS_IP_Private.h-union-to-struct.patch
@@ -1,26 +1,13 @@
-From b7fbcc3979324838ec240b28717bfd7918bbb388 Mon Sep 17 00:00:00 2001
-From: Kareem Khazem <karkhaz@amazon.com>
-Date: Thu, 31 Jan 2019 15:07:52 -0800
-Subject: [PATCH 2/4] Change FreeRTOS_IP_Private.h union to struct
-
-This patch should be removed soon: It is for a CBMC issue being fixed now.
----
- libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
-index 6006f89f0..d1a0cf898 100644
+index fce5b3150..cd18f15da 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/include/FreeRTOS_IP_Private.h
-@@ -643,7 +643,7 @@ typedef struct XSOCKET
- 	/* Before accessing any member of this structure, it should be confirmed */
- 	/* that the protocol corresponds with the type of structure */
+@@ -658,7 +658,7 @@
+         /* Before accessing any member of this structure, it should be confirmed */
+         /* that the protocol corresponds with the type of structure */
  
--	union
-+	struct
- 	{
- 		IPUDPSocket_t xUDP;
- 		#if( ipconfigUSE_TCP == 1 )
--- 
-2.21.0
-
+-        union
++        struct
+         {
+             IPUDPSocket_t xUDP;
+             #if ( ipconfigUSE_TCP == 1 )

--- a/tools/cbmc/patches/remove-static-in-freertos-dhcp.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-dhcp.patch
@@ -1,64 +1,64 @@
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
-index 04b0487..d6e74a9 100644
+index d41c6e73b..199cd05f1 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DHCP.c
-@@ -156,7 +156,11 @@ struct xDHCPMessage_IPv4
- typedef struct xDHCPMessage_IPv4 DHCPMessage_IPv4_t;
+@@ -154,7 +154,11 @@
+     typedef struct xDHCPMessage_IPv4 DHCPMessage_IPv4_t;
  
  /* The UDP socket used for all incoming and outgoing DHCP traffic. */
-+#ifdef CBMC
-+Socket_t xDHCPSocket;
-+#else
- static Socket_t xDHCPSocket;
-+#endif
++    #ifdef CBMC
++    Socket_t xDHCPSocket;
++    #else
+     static Socket_t xDHCPSocket;
++    #endif
  
- #if( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
- 	/* Define the Link Layer IP address: 169.254.x.x */
-@@ -179,7 +183,11 @@ static void prvSendDHCPDiscover( void );
+     #if ( ipconfigDHCP_FALL_BACK_AUTO_IP != 0 )
+         /* Define the Link Layer IP address: 169.254.x.x */
+@@ -177,7 +181,11 @@
  /*
   * Interpret message received on the DHCP socket.
   */
-+#ifdef CBMC
-+BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
-+#else
- static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
-+#endif
++    #ifdef CBMC
++    BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
++    #else
+     static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType );
++    #endif
  
  /*
   * Generate a DHCP request packet, and send it on the DHCP socket.
-@@ -204,7 +212,11 @@ static uint8_t *prvCreatePartDHCPMessage( struct freertos_sockaddr *pxAddress,
+@@ -202,7 +210,11 @@
  /*
   * Create the DHCP socket, if it has not been created already.
   */
-+#ifdef CBMC
-+void prvCreateDHCPSocket( void );
-+#else
- static void prvCreateDHCPSocket( void );
-+#endif
++    #ifdef CBMC
++    void prvCreateDHCPSocket( void );
++    #else
+     static void prvCreateDHCPSocket( void );
++    #endif
  
  /*
   * Close the DHCP socket.
-@@ -223,7 +235,11 @@ static void prvCloseDHCPSocket( void );
+@@ -221,7 +233,11 @@
  /*-----------------------------------------------------------*/
  
  /* Hold information in between steps in the DHCP state machine. */
-+#ifdef CBMC
-+DHCPData_t xDHCPData;
-+#else
- static DHCPData_t xDHCPData;
-+#endif
++    #ifdef CBMC
++    DHCPData_t xDHCPData;
++    #else
+     static DHCPData_t xDHCPData;
++    #endif
  
  /*-----------------------------------------------------------*/
  
-@@ -623,7 +639,11 @@ static void prvInitialiseDHCP( void )
- }
+@@ -630,7 +646,11 @@
+     }
  /*-----------------------------------------------------------*/
  
-+#ifdef CBMC
-+BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
-+#else
- static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
-+#endif
- {
- uint8_t *pucUDPPayload;
- int32_t lBytes;
++    #ifdef CBMC
++    BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
++    #else
+     static BaseType_t prvProcessDHCPReplies( BaseType_t xExpectedMessageType )
++    #endif
+     {
+         uint8_t * pucUDPPayload;
+         int32_t lBytes;

--- a/tools/cbmc/patches/remove-static-in-freertos-dns.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-dns.patch
@@ -1,100 +1,100 @@
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
-index 480d50b..5557253 100644
+index cd00441a7..352471f7c 100755
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_DNS.c
-@@ -114,7 +114,11 @@ static Socket_t prvCreateDNSSocket( void );
+@@ -121,7 +121,11 @@
  /*
   * Create the DNS message in the zero copy buffer passed in the first parameter.
   */
-+#ifdef CBMC
-+size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
-+#else
- static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
-+#endif
- 								   const char *pcHostName,
- 								   TickType_t uxIdentifier );
++    #ifdef CBMC
++    size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
++    #else
+     static size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
++    #endif
+                                        const char * pcHostName,
+                                        TickType_t uxIdentifier );
  
-@@ -122,7 +126,11 @@ static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
+@@ -129,7 +133,11 @@
   * Simple routine that jumps over the NAME field of a resource record.
   * It returns the number of bytes read.
   */
-+#ifdef CBMC
-+size_t prvSkipNameField( const uint8_t *pucByte,
-+#else
- static size_t prvSkipNameField( const uint8_t *pucByte,
-+#endif
- 								size_t uxLength );
++    #ifdef CBMC
++    size_t prvSkipNameField( const uint8_t * pucByte,
++    #else
+     static size_t prvSkipNameField( const uint8_t * pucByte,
++    #endif
+                                     size_t uxLength );
  
  /*
-@@ -130,7 +138,11 @@ static size_t prvSkipNameField( const uint8_t *pucByte,
+@@ -137,7 +145,11 @@
   * The parameter 'xExpected' indicates whether the identifier in the reply
   * was expected, and thus if the DNS cache may be updated with the reply.
   */
-+#ifdef CBMC
-+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-+#else
- static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-+#endif
- 								  size_t uxBufferLength,
- 								  BaseType_t xExpected );
++    #ifdef CBMC
++    uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
++    #else
+     static uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
++    #endif
+                                       size_t uxBufferLength,
+                                       BaseType_t xExpected );
  
-@@ -184,7 +196,11 @@ static uint32_t prvGetHostByName( const char *pcHostName,
+@@ -191,7 +203,11 @@
  
  
- #if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
-+#ifdef CBMC
-+	size_t prvReadNameField( const uint8_t *pucByte,
-+#else
- 	static size_t prvReadNameField( const uint8_t *pucByte,
-+#endif
- 									size_t uxRemainingBytes,
- 									char *pcName,
- 									size_t uxDestLen );
-@@ -758,7 +774,11 @@ TickType_t uxWriteTimeOut_ticks = ipconfigDNS_SEND_BLOCK_TIME_TICKS;
- }
+     #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
++        #ifdef CBMC
++        size_t prvReadNameField( const uint8_t * pucByte,
++        #else
+         static size_t prvReadNameField( const uint8_t * pucByte,
++        #endif
+                                         size_t uxRemainingBytes,
+                                         char * pcName,
+                                         size_t uxDestLen );
+@@ -800,7 +816,11 @@
+     }
  /*-----------------------------------------------------------*/
  
-+#ifdef CBMC
-+size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
-+#else
- static size_t prvCreateDNSMessage( uint8_t *pucUDPPayloadBuffer,
-+#endif
- 								   const char *pcHostName,
- 								   TickType_t uxIdentifier )
- {
-@@ -838,7 +858,11 @@ static const DNSMessage_t xDefaultPartDNSHeader =
++    #ifdef CBMC
++    size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
++    #else
+     static size_t prvCreateDNSMessage( uint8_t * pucUDPPayloadBuffer,
++    #endif
+                                        const char * pcHostName,
+                                        TickType_t uxIdentifier )
+     {
+@@ -880,7 +900,11 @@
  
- #if( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
+     #if ( ipconfigUSE_DNS_CACHE == 1 ) || ( ipconfigDNS_USE_CALLBACKS == 1 )
  
-+#ifdef CBMC
-+	size_t prvReadNameField( const uint8_t *pucByte,
-+#else
- 	static size_t prvReadNameField( const uint8_t *pucByte,
-+#endif
- 									size_t uxRemainingBytes,
- 									char *pcName,
- 									size_t uxDestLen )
-@@ -932,7 +956,11 @@ static const DNSMessage_t xDefaultPartDNSHeader =
- #endif	/* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
++        #ifdef CBMC
++        size_t prvReadNameField( const uint8_t * pucByte,
++        #else
+         static size_t prvReadNameField( const uint8_t * pucByte,
++        #endif
+                                         size_t uxRemainingBytes,
+                                         char * pcName,
+                                         size_t uxDestLen )
+@@ -980,7 +1004,11 @@
+     #endif /* ipconfigUSE_DNS_CACHE || ipconfigDNS_USE_CALLBACKS */
  /*-----------------------------------------------------------*/
  
-+#ifdef CBMC
-+size_t prvSkipNameField( const uint8_t *pucByte,
-+#else
- static size_t prvSkipNameField( const uint8_t *pucByte,
-+#endif
- 								size_t uxLength )
- {
- size_t uxChunkLength;
-@@ -1050,7 +1078,11 @@ size_t uxPayloadSize;
- #endif /* ipconfigUSE_NBNS */
++    #ifdef CBMC
++    size_t prvSkipNameField( const uint8_t * pucByte,
++    #else
+     static size_t prvSkipNameField( const uint8_t * pucByte,
++    #endif
+                                     size_t uxLength )
+     {
+         size_t uxChunkLength;
+@@ -1099,7 +1127,11 @@
+     #endif /* ipconfigUSE_NBNS */
  /*-----------------------------------------------------------*/
  
-+#ifdef CBMC
-+uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-+#else
- static uint32_t prvParseDNSReply( uint8_t *pucUDPPayloadBuffer,
-+#endif
- 								  size_t uxBufferLength,
- 								  BaseType_t xExpected )
- {
++    #ifdef CBMC
++    uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
++    #else
+     static uint32_t prvParseDNSReply( uint8_t * pucUDPPayloadBuffer,
++    #endif
+                                       size_t uxBufferLength,
+                                       BaseType_t xExpected )
+     {

--- a/tools/cbmc/patches/remove-static-in-freertos-tcp-ip.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-tcp-ip.patch
@@ -1,75 +1,76 @@
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
-index 7a2c00c68..cb537b347 100644
+index 6c37da5e2..bb366bc92 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_IP.c
-@@ -198,14 +198,22 @@ static BaseType_t prvTCPPrepareConnect( FreeRTOS_Socket_t *pxSocket );
+@@ -202,7 +202,11 @@
  /*
   * Parse the TCP option(s) received, if present.
   */
-+#ifdef CBMC
-+void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer );
-+#else
- static void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer );
-+#endif
++    #ifdef CBMC
++    void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
++    #else
+     static void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
++    #endif
+                                  const NetworkBufferDescriptor_t * pxNetworkBuffer );
  
  /*
-  * Identify and deal with a single TCP header option, advancing the pointer to
+@@ -210,7 +214,11 @@
   * the header. This function returns pdTRUE or pdFALSE depending on whether the
   * caller should continue to parse more header options or break the loop.
   */
-+#ifdef CBMC
-+size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-+#else
- static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-+#endif
- 											 size_t uxTotalLength,
- 											 FreeRTOS_Socket_t * const pxSocket,
- 											 BaseType_t xHasSYNFlag );
-@@ -215,7 +223,11 @@ static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
- 	 * Skip past TCP header options when doing Selective ACK, until there are no
- 	 * more options left.
- 	 */
-+	#ifdef CBMC
-+	void prvReadSackOption( const uint8_t * const pucPtr,
-+	#else
- 	static void prvReadSackOption( const uint8_t * const pucPtr,
-+	#endif
- 								   size_t uxIndex,
- 								   FreeRTOS_Socket_t * const pxSocket );
- #endif/* ( ipconfigUSE_TCP_WIN == 1 ) */
-@@ -1137,7 +1149,11 @@ uint32_t ulInitialSequenceNumber = 0;
++    #ifdef CBMC
++    size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
++    #else
+     static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
++    #endif
+                                                  size_t uxTotalLength,
+                                                  FreeRTOS_Socket_t * const pxSocket,
+                                                  BaseType_t xHasSYNFlag );
+@@ -221,7 +229,11 @@
+          * Skip past TCP header options when doing Selective ACK, until there are no
+          * more options left.
+          */
++        #ifdef CBMC
++        void prvReadSackOption( const uint8_t * const pucPtr,
++        #else
+         static void prvReadSackOption( const uint8_t * const pucPtr,
++        #endif
+                                        size_t uxIndex,
+                                        FreeRTOS_Socket_t * const pxSocket );
+     #endif /* ( ipconfigUSE_TCP_WIN == 1 ) */
+@@ -1188,7 +1200,11 @@
   * that: ((pxTCPHeader->ucTCPOffset & 0xf0) > 0x50), meaning that the TP header
   * is longer than the usual 20 (5 x 4) bytes.
   */
-+#ifdef CBMC
-+void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer )
-+#else
- static void prvCheckOptions( FreeRTOS_Socket_t *pxSocket, const NetworkBufferDescriptor_t *pxNetworkBuffer )
-+#endif
- {
- size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
- const ProtocolHeaders_t *pxProtocolHeaders = ipPOINTER_CAST( ProtocolHeaders_t *,
-@@ -1199,7 +1215,11 @@ uint8_t ucLength;
- }
++    #ifdef CBMC
++    void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
++    #else
+     static void prvCheckOptions( FreeRTOS_Socket_t * pxSocket,
++    #endif
+                                  const NetworkBufferDescriptor_t * pxNetworkBuffer )
+     {
+         size_t uxTCPHeaderOffset = ipSIZE_OF_ETH_HEADER + xIPHeaderSize( pxNetworkBuffer );
+@@ -1258,7 +1274,11 @@
+     }
  /*-----------------------------------------------------------*/
  
-+#ifdef CBMC
-+size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-+#else
- static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
-+#endif
- 											 size_t uxTotalLength,
- 											 FreeRTOS_Socket_t * const pxSocket,
- 											 BaseType_t xHasSYNFlag )
-@@ -1331,7 +1351,11 @@ TCPWindow_t *pxTCPWindow = &( pxSocket->u.xTCP.xTCPWindow );
++    #ifdef CBMC
++    size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
++    #else
+     static size_t prvSingleStepTCPHeaderOptions( const uint8_t * const pucPtr,
++    #endif
+                                                  size_t uxTotalLength,
+                                                  FreeRTOS_Socket_t * const pxSocket,
+                                                  BaseType_t xHasSYNFlag )
+@@ -1398,7 +1418,11 @@
  /*-----------------------------------------------------------*/
  
- #if( ipconfigUSE_TCP_WIN == 1 )
-+	#ifdef CBMC
-+	void prvReadSackOption( const uint8_t * const pucPtr,
-+	#else
- 	static void prvReadSackOption( const uint8_t * const pucPtr,
-+	#endif
- 								   size_t uxIndex,
- 								   FreeRTOS_Socket_t * const pxSocket )
- 	{
+     #if ( ipconfigUSE_TCP_WIN == 1 )
++        #ifdef CBMC
++        void prvReadSackOption( const uint8_t * const pucPtr,
++        #else
+         static void prvReadSackOption( const uint8_t * const pucPtr,
++        #endif
+                                        size_t uxIndex,
+                                        FreeRTOS_Socket_t * const pxSocket )
+         {

--- a/tools/cbmc/patches/remove-static-in-freertos-tcp-win.patch
+++ b/tools/cbmc/patches/remove-static-in-freertos-tcp-win.patch
@@ -1,17 +1,16 @@
 diff --git a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c
-index 0078ab313..b0cccbad8 100644
+index 82aa4d8b2..f2c1e702c 100644
 --- a/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c
 +++ b/libraries/freertos_plus/standard/freertos_plus_tcp/source/FreeRTOS_TCP_WIN.c
-@@ -192,8 +192,12 @@ extern void vListInsertGeneric( List_t * const pxList, ListItem_t * const pxNewL
+@@ -206,7 +206,11 @@ extern void vListInsertGeneric( List_t * const pxList,
  
  /* List of free TCP segments. */
- #if( ipconfigUSE_TCP_WIN == 1 )
-+#ifdef CBMC
-+	List_t xSegmentList;
-+#else
- 	static List_t xSegmentList;
+ #if ( ipconfigUSE_TCP_WIN == 1 )
++    #ifdef CBMC
++    List_t xSegmentList;
++    #else
+     static List_t xSegmentList;
++    #endif
  #endif
-+#endif
  
  /* Logging verbosity level. */
- BaseType_t xTCPWindowLoggingLevel = 0;


### PR DESCRIPTION
This pull request updates the patches used to prepare the source tree for CBMC proof so that they apply to the reformatting of the TCP code with uncrustify.

This commit has been tested in continuous integration with the pull request [2291](https://github.com/aws/amazon-freertos/pull/2291).